### PR TITLE
Fix Cloud Run env var formatting

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -93,7 +93,7 @@ jobs:
             --platform managed \
             --region $REGION \
             --allow-unauthenticated \
-            --set-env-vars $(cat ./backend/.env | grep -v '^#' | xargs)
+            --set-env-vars $(grep -v '^#' ./backend/.env | paste -sd ',' -)
 
       - name: Deploy frontend to Cloud Run
         run: |
@@ -102,7 +102,7 @@ jobs:
             --platform managed \
             --region $REGION \
             --allow-unauthenticated \
-            --set-env-vars $(cat ./frontend/.env.local | grep -v '^#' | xargs)
+            --set-env-vars $(grep -v '^#' ./frontend/.env.local | paste -sd ',' -)
 
 # Required GitHub Secrets:
 # - GCP_PROJECT_ID: Your Google Cloud project ID


### PR DESCRIPTION
## Summary
- fix `--set-env-vars` formatting in GCP deploy workflow

## Testing
- `pytest -q` *(fails: Configuration object missing SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6849f88fad6c832cb04bc3bb1a1235a4