### PR TITLE
Fix Cloud Run env var formatting

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -74,6 +74,8 @@ jobs:
           cat <<EOF > ./frontend/.env.local
           NEXT_PUBLIC_SUPABASE_URL=${{ secrets.SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_URL=${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
           EOF
 
       - name: Build and push backend Docker image
@@ -93,7 +95,7 @@ jobs:
             --platform managed \
             --region $REGION \
             --allow-unauthenticated \
-            --set-env-vars $(cat ./backend/.env | grep -v '^#' | xargs)
+            --set-env-vars $(grep -v '^#' ./backend/.env | paste -sd ',' -)
 
       - name: Deploy frontend to Cloud Run
         run: |
@@ -102,7 +104,7 @@ jobs:
             --platform managed \
             --region $REGION \
             --allow-unauthenticated \
-            --set-env-vars $(cat ./frontend/.env.local | grep -v '^#' | xargs)
+            --set-env-vars $(grep -v '^#' ./frontend/.env.local | paste -sd ',' -)
 
 # Required GitHub Secrets:
 # - GCP_PROJECT_ID: Your Google Cloud project ID


### PR DESCRIPTION
## Summary
- fix `--set-env-vars` formatting in GCP deploy workflow
- add required SUPABASE_URL variables to frontend build env

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for dotenv and mcp)*

------
https://chatgpt.com/codex/tasks/task_e_6849f88fad6c832cb04bc3bb1a1235a4