### PR TITLE
Fix env vars for GCP deploy workflow

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -76,6 +76,8 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL=${{ secrets.SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
           NEXT_PUBLIC_BACKEND_URL=${{ secrets.NEXT_PUBLIC_BACKEND_URL }}
+          SUPABASE_URL=${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
           EOF
 
       - name: Build and push backend Docker image
@@ -95,7 +97,7 @@ jobs:
             --platform managed \
             --region $REGION \
             --allow-unauthenticated \
-            --set-env-vars $(cat ./backend/.env | grep -v '^#' | xargs)
+            --set-env-vars $(grep -v '^#' ./backend/.env | paste -sd ',' -)
 
       - name: Deploy frontend to Cloud Run
         run: |
@@ -104,7 +106,7 @@ jobs:
             --platform managed \
             --region $REGION \
             --allow-unauthenticated \
-            --set-env-vars $(cat ./frontend/.env.local | grep -v '^#' | xargs)
+            --set-env-vars $(grep -v '^#' ./frontend/.env.local | paste -sd ',' -)
 
 # Required GitHub Secrets:
 # - GCP_PROJECT_ID: Your Google Cloud project ID


### PR DESCRIPTION
## Summary
- ensure Cloud Run receives comma-separated env vars
- include server Supabase values in frontend `.env.local`

## Testing
- `pytest -q` *(fails: Configuration object has no attribute `SUPABASE_URL`)*

------
https://chatgpt.com/codex/tasks/task_e_684a16bd3154832cb00845143c9f2ff4