### PR TITLE
Fix Cloud Run port handling

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -44,7 +44,7 @@ EXPOSE 8000
 CMD ["sh", "-c", "gunicorn api:app \
      --workers $WORKERS \
      --worker-class uvicorn.workers.UvicornWorker \
-     --bind 0.0.0.0:8000 \
+     --bind 0.0.0.0:${PORT:-8000} \
      --timeout 1800 \
      --graceful-timeout 600 \
      --keep-alive 1800 \

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -179,9 +179,15 @@ Example configuration:
 ```sh
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+# Backend listens on port 8000 by default. Cloud Run sets $PORT to 8080
 NEXT_PUBLIC_BACKEND_URL=http://backend:8000/api
 NEXT_PUBLIC_URL=http://localhost:3000
 ```
+
+On Google Cloud Run the container is automatically provided a `PORT` environment
+variable (default `8080`). The backend Dockerfile now respects this variable, so
+no change is required beyond setting `NEXT_PUBLIC_BACKEND_URL` to the public
+address of your backend.
 
 ## Post-Installation Steps
 


### PR DESCRIPTION
## Summary
- allow backend Dockerfile to respect `PORT` environment variable
- document Cloud Run port expectations

## Testing
- `python -m py_compile backend/api.py`


------
https://chatgpt.com/codex/tasks/task_e_684a2171bfc4832c9ccc86d09d8dbb1c